### PR TITLE
Add dockerfile + instructions to build and run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Starting image
+FROM ubuntu:22.04
+
+# Install prerequisites
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update
+RUN apt install -y python3 python3-pip libpython3-dev git
+
+# Install SWI-Prolog unstable
+RUN apt install -y software-properties-common
+RUN apt-add-repository -y ppa:swi-prolog/devel
+RUN apt update
+RUN apt install -y swi-prolog
+
+# Install Janus for SWI-Prolog
+RUN pip install git+https://github.com/SWI-Prolog/packages-swipy.git
+
+# Install PySWIP for SWI-Prolog
+RUN pip install git+https://github.com/logicmoo/pyswip.git
+
+# Create user
+ENV USER=user
+RUN useradd -m -G sudo -p "" user
+RUN chsh -s /bin/bash user
+USER ${USER}
+ENV HOME=/home/${USER}
+WORKDIR ${HOME}
+
+# Install SWI-Prolog packages
+RUN swipl -g "pack_install(predicate_streams,[interactive(false)])" -t halt
+RUN swipl -g "pack_install('https://github.com/TeamSPoon/logicmoo_utils.git',[insecure(true),interactive(false),git(true),verify(false)])" -t halt
+RUN swipl -g "pack_install(dictoo,[interactive(false)])" -t halt
+
+# Install MeTTaLog
+WORKDIR ${HOME}
+RUN git clone https://github.com/logicmoo/vspace-metta.git
+
+# Update PATH
+RUN echo >> ${HOME}/.bashrc
+RUN echo "# For MeTTaLog" >> ${HOME}/.bashrc
+RUN echo "export PATH=${PATH}:${HOME}/vspace-metta" >> ${HOME}/.bashrc

--- a/README.md
+++ b/README.md
@@ -72,7 +72,45 @@ find ./data/ftp.flybase.org/releases/FB2023_04/precomputed_files/ -type f -name 
 
 ```
 
+## :whale: Docker
 
+To build a docker image containing MeTTaLog readily available run the
+following command
+
+```bash
+docker build -t mettalog .
+```
+
+You may then enter a corresponding containter with the following
+command
+
+```bash
+docker run --rm -it --entrypoint bash mettalog
+```
+
+Once inside the container you may enter the MeTTaLog REPL with the
+following command
+
+```bash
+MeTTa --repl
+```
+
+or run a metta script as follows
+
+```bash
+MeTTa myprg.metta
+```
+
+Beware that the container will be removed after leaving it.  If you
+wish to keep it, then remove the `--rm` flag from the command line
+used to enter the container.
+
+Docker has a rich functionality set.  In particular it allows you to
+[copy](https://docs.docker.com/engine/reference/commandline/container_cp/)
+files back and forth between the host and the container.  For more
+information about Docker you may refer to its
+[manuals](https://docs.docker.com/manuals/) and its [reference
+documentation](https://docs.docker.com/reference/).
 
 ## :computer: Various Usages and Demos
 


### PR DESCRIPTION
For now it branches off from `ubuntu:22.04`.  It would probably be better to branch off from https://hub.docker.com/r/trueagi/hyperon since some of MeTTaLog tools rely on Hyperon.  However, we leave that aside since that Hyperon image is not actively maintained, but should hopefully be in the future.